### PR TITLE
Declarative substeps

### DIFF
--- a/css/impress-demo.css
+++ b/css/impress-demo.css
@@ -407,6 +407,48 @@ a:focus {
     display: inline-block;
 }
 
+.animated {
+    -webkit-animation-duration: 0.7s;
+    -moz-animation-duration: 0.7s;
+    animation-duration: 0.7s;
+
+    -webkit-animation-timing-function: ease-in;
+    -moz-animation-timing-function: ease-in;
+    animation-timing-function: ease-in;
+
+    -webkit-animation-iteration-count: 1;
+    -moz-animation-iteration-count: 1;
+    animation-iteration-count: 1;
+
+    -webkit-animation-fill-mode: forwards;
+    -moz-animation-fill-mode: forwards;
+    animation-fill-mode: forwards;
+}
+
+.animated.two {
+    -webkit-animation-delay: 0.7s;
+    -moz-animation-delay: 0.7s;
+    animation-delay: 0.7s;
+}
+
+.animated.three {
+    -webkit-animation-delay: 1.4s;
+    -moz-animation-delay: 1.4s;
+    animation-delay: 1.4s;
+}
+
+@-webkit-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
+@-moz-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
+@keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
+
+.substep.active.animated.fadeIn,
+.substep.active .animated.fadeIn {
+    opacity:0;
+    -webkit-animation-name: fadeIn;
+    -moz-animation-name: fadeIn;
+    animation-name: fadeIn;
+}
+
 /*
     There is nothing really special about 'use the source, Luke' step, too,
     except maybe of the Yoda background.

--- a/css/impress-demo.css
+++ b/css/impress-demo.css
@@ -399,11 +399,11 @@ a:focus {
     height: 230px; /* 1 */
 }
 
-#substeps .areThere, #substeps .ofCourse {
+.substep {
     display: none;
 }
 
-#substeps .areThereVisible, #substeps .ofCourceVisible {
+.substep.active {
     display: inline-block;
 }
 

--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
 
     <div id="substeps" class="step" data-x="6700" data-y="-100" data-scale="6" data-stepId="substeps">
         <p>Are there <b>substeps</b> too?</p> 
-        <p><span class="areThere">Are there?</span> <span class="ofCourse">Of course!</span></p>
+        <p><span class="substep">Are there?</span> <span class="substep">Of course!</span></p>
     </div>
     
     <div id="source" class="step" data-x="6300" data-y="2000" data-rotate="20" data-scale="4">
@@ -412,20 +412,6 @@ if ("ontouchstart" in document.documentElement) {
         For some example uses of this API check the last part of the source of impress.js where the API
         is used in event handlers.
     */
-
-    // Subscribe to the `impress:init`-event to add the actions to the steps after impress is initialized.
-    document.getElementById("impress").addEventListener("impress:init", function(){ 
-        var api = impress();
-         
-        api.addActionToStep('substeps', function(stepElement){ stepElement.querySelector(".areThere").classList.add("areThereVisible"); });
-        api.addActionToStep('substeps', function(stepElement){ stepElement.querySelector(".ofCourse").classList.add("ofCourceVisible"); });
-        
-        api.addResetActionToStep('substeps', function(stepElement){ 
-            stepElement.querySelector(".areThere").classList.remove("areThereVisible");
-            stepElement.querySelector(".ofCourse").classList.remove("ofCourceVisible");
-        });
-    });
-
     impress().init();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -273,7 +273,12 @@
 
     <div id="substeps" class="step" data-x="6700" data-y="-100" data-scale="6" data-stepId="substeps">
         <p>Are there <b>substeps</b> too?</p> 
-        <p><span class="substep">Are there?</span> <span class="substep">Of course!</span></p>
+        <p>
+            <span class="substep animated fadeIn">Are there?</span>
+            <span class="substep">
+                <span class="animated fadeIn">Of</span>
+                <span class="animated fadeIn two">course!</span>
+        </p>
     </div>
     
     <div id="source" class="step" data-x="6300" data-y="2000" data-rotate="20" data-scale="4">

--- a/js/impress.js
+++ b/js/impress.js
@@ -322,6 +322,23 @@
             }
             
             stepsData["impress-" + el.id] = step;
+
+            // Adds actions for each substep
+            var substeps = $$(".substep", el);
+
+            substeps.forEach(function(substep) {
+                step.actions.push(function() {
+                    substep.classList.add("active");
+                });
+            });
+
+            (function(substeps){
+                step.resetAction = function() {
+                    substeps.forEach(function(substep) {
+                        substep.classList.remove("active");
+                    });
+                };
+            })(substeps);
             
             css(el, {
                 position: "absolute",


### PR DESCRIPTION
Achieving same goal with CSS classes : _'substep'_ to match each steps, initially hidden, and _'active'_ to reveal reached steps.
Initialized directly in _'initStep'_, targeting _'.substep'_ elements. Then adding _'actions'_ and _'resetAction'_ callback functions for each step's data.
Cherry on the cake, a little fading effect.
